### PR TITLE
apply-patch.sh: fix patch file finding issue 

### DIFF
--- a/apply-patch.sh
+++ b/apply-patch.sh
@@ -25,15 +25,11 @@ if [ ! -d $patch_dir ];then
     exit 1
 fi
 
-echo "Begin to apply patches from $patch_dir"
 cd $patch_dir
-pwd
-for p in `find *`
+leaf_dirs=$(find . -type d -exec sh -c '(ls -p "{}" | grep / > /dev/null) || echo "{}"' \;)
+for p in $leaf_dirs
 do
-    # if this is a patch file that ends with .patch
-    if [[ $p == *.patch ]]; then
-        project_dir=$(dirname $p)
-        echo "process project: $project_dir"
-        git -C $src/$project_dir apply --reject $patch_dir/$p || echo "*****[ERROR]***** apply failed: $p"
-    fi
+    echo
+    echo "process project: $p"
+    git -C $src/$p am --reject $patch_dir/$p/* || echo "*****[ERROR]***** apply failed: $p"
 done

--- a/apply-patch.sh
+++ b/apply-patch.sh
@@ -25,10 +25,15 @@ if [ ! -d $patch_dir ];then
     exit 1
 fi
 
+echo "Begin to apply patches from $patch_dir"
 cd $patch_dir
-for p in `find * -links 2`
+pwd
+for p in `find *`
 do
-    echo
-    echo "process project: $p"
-    git -C $src/$p am --reject $patch_dir/$p/* || echo "*****[ERROR]***** apply failed: $p"
+    # if this is a patch file that ends with .patch
+    if [[ $p == *.patch ]]; then
+        project_dir=$(dirname $p)
+        echo "process project: $project_dir"
+        git -C $src/$project_dir apply --reject $patch_dir/$p || echo "*****[ERROR]***** apply failed: $p"
+    fi
 done


### PR DESCRIPTION
Current script finds patch files that have two hard links. But the links in fact seem to be soft links (at least after git clone), causing the script to miss all patch files. So maybe we should use the `.patch` suffix to find the patch files instead.